### PR TITLE
Update Dependabot schedule to every 2-3 weeks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,8 @@ updates:
           - '/'
           - '/data/zip-download'
       schedule:
-          interval: 'weekly'
-          day: 'tuesday'
-          time: '03:00'
+          interval: 'cron'
+          cronjob: '0 3 */2& * 2'
           timezone: 'Europe/London'
       assignees: ['cmenon12']
       labels:
@@ -42,9 +41,8 @@ updates:
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
-          interval: 'weekly'
-          day: 'tuesday'
-          time: '03:00'
+          interval: 'cron'
+          cronjob: '0 3 */2& * 2'
           timezone: 'Europe/London'
       assignees: ['cmenon12']
       labels:


### PR DESCRIPTION
<!-- markdownlint-disable no-multiple-blanks first-line-h1 -->

<!-- Thank you for taking the time to contribute to this project! Please complete the template below. -->
<!-- Please open your pull request as a draft, and only mark it as ready for review when you have completed the checklist below. -->

## Description
<!--- Describe your changes in detail. -->

Change the Dependabot schedule to cron `0 3 */2& * 2`, which should be every 2-3 weeks. 
- It should run every Tuesday providing that Tuesday is an odd-numbered day of the month, which works out as every 2-3 weeks.
- This fixes the change that was reverted in #46.

This is as recommended by [GitHub Support](https://support.github.com/ticket/personal/0/3771020), who said:

> I heard back from our engineers and `0 3 */2 * 2` translates to `At 3:00 AM on every odd days of the month OR every Tuesday` which is why it is triggering snyc every 2 days. For your needs, you would have to add `&` after the day specifier to have an `AND` logic. They suggested using `0 3 */2& * 2` to get your desired results.


## Checklist before marking as ready for review

Before marking as ready for review, please check that you have:

- [x] Added appropriate and passing tests for the changes I made.
- [x] Not broken any existing functionality or tests.
- [x] Not introduced any new linting or formatting errors.
- [x] Only added new dependencies that are necessary, do not introduce security vulnerabilities, and with tilde (~) version ranges.
- [x] Checked and resolved UI accessibility issues using Axe devtools. Unresolved issues are described above.
- [x] Updated the documentation if necessary.

Check the [contributing guidelines](./docs/CONTRIBUTING.md) for more details.

## Screenshots (if appropriate)
