### PR TITLE
Always use `--ignore-scripts` when installing npm dependencies

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
   eslint:
     needs: setup
@@ -48,7 +48,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run ESLint
         run: npm run lint -- --max-warnings=0
@@ -71,7 +71,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run npm audit with moderate threshold
         run: npm audit --audit-level=moderate
@@ -94,7 +94,7 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run tests with coverage
         run: npm run test -- --coverage --silent --maxWorkers=1

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --omit=dev
+RUN npm ci --ignore-scripts --omit=dev
 
 # Copy source code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Before you can run the application, you need to set up a MongoDB database.
 2. Install the latest version of Node.js v20 with `nvm install 20` and switch to it with `nvm use 20`.
 3. Check Node JS is ready with the right version using `node --version`.
 4. Copy the example environment file with `cp .env.example .env` and fill out your environment variables (including the MongoDB connection string from above; [see below](#environment-variables) for details).
-5. Run `npm install` to install the dependencies.
+5. Run `npm install --ignore-scripts` to install the dependencies safely.
 6. Run the application with `npm run start` and visit <http://localhost:3001>.
 
 ### Environment variables

--- a/data/zip-download/.npmrc
+++ b/data/zip-download/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/data/zip-download/README.md
+++ b/data/zip-download/README.md
@@ -6,6 +6,6 @@ This is a ZIP download of your prototype that you can run locally within an Expr
 2. Install the latest version of Node.js v20 with `nvm install 20` and switch to it with `nvm use 20`.
 3. Check Node JS is ready with the right version with `node --version`.
 4. Download and extract the ZIP file, and open a terminal window within the extracted folder.
-5. Run `npm install` to install the project dependencies.
+5. Run `npm install --ignore-scripts` to install the project dependencies safely.
 6. Run `npm run start` to run the project.
 7. Visit <http://localhost:3000/your-prototype/start> to test the prototype.

--- a/docs/help/test-a-prototype.md
+++ b/docs/help/test-a-prototype.md
@@ -12,6 +12,6 @@ The Nunjucks template files and associated files can also be downloaded in a ZIP
 2. Install the latest version of Node.js v20 with `nvm install 20` and switch to it with `nvm use 20`.
 3. Check Node JS is ready with the right version with `node --version`.
 4. Download and extract the ZIP file, and open a terminal window within the extracted folder.
-5. Run `npm install` to install the project dependencies.
+5. Run `npm install --ignore-scripts` to install the project dependencies safely.
 6. Run `npm run start` to run the project.
 7. Visit <http://localhost:3000/your-prototype/start> to test the prototype, replacing `your-prototype` with your ZIP download name.


### PR DESCRIPTION
<!-- markdownlint-disable no-multiple-blanks first-line-h1 -->

<!-- Thank you for taking the time to contribute to this project! Please complete the template below. -->
<!-- Please open your pull request as a draft, and only mark it as ready for review when you have completed the checklist below. -->

## Description
<!--- Describe your changes in detail. -->

Always use `--ignore-scripts` when installing npm dependencies. 

This is to mitigate the SHA1-Hulud supply-chain attack.

<!--- List any issues that this PR addresses here (e.g., #3, #4) -->
Related issues: none

## Checklist before marking as ready for review

Before marking as ready for review, please check that you have:

- [x] Added appropriate and passing tests for the changes I made.
- [x] Not broken any existing functionality or tests.
- [x] Not introduced any new linting or formatting errors.
- [x] Only added new dependencies that are necessary, do not introduce security vulnerabilities, and with tilde (~) version ranges.
- [x] Checked and resolved UI accessibility issues using Axe devtools. Unresolved issues are described above.
- [x] Updated the documentation if necessary.

Check the [contributing guidelines](./docs/CONTRIBUTING.md) for more details.

## Screenshots (if appropriate)
