### PR TITLE
Fix vulnerability in validator dependency with `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12462,9 +12462,9 @@
             }
         },
         "node_modules/validator": {
-            "version": "13.15.20",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
-            "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
+            "version": "13.15.23",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+            "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"


### PR DESCRIPTION
<!-- markdownlint-disable no-multiple-blanks first-line-h1 -->

<!-- Thank you for taking the time to contribute to this project! Please complete the template below. -->
<!-- Please open your pull request as a draft, and only mark it as ready for review when you have completed the checklist below. -->

## Description
<!--- Describe your changes in detail. -->

The only change is to update validator from 13.15.20 to 13.15.23 in package-lock.json.

validator  <13.15.22
Severity: high
Validator is Vulnerable to Incomplete Filtering of One or More Instances of Special Elements - https://github.com/advisories/GHSA-vghf-hv5q-vc2g

<!--- List any issues that this PR addresses here (e.g., #3, #4) -->
Related issues: none

## Checklist before marking as ready for review

Before marking as ready for review, please check that you have:

- [x] Added appropriate and passing tests for the changes I made.
- [x] Not broken any existing functionality or tests.
- [x] Not introduced any new linting or formatting errors.
- [x] Only added new dependencies that are necessary, do not introduce security vulnerabilities, and with tilde (~) version ranges.
- [x] Checked and resolved UI accessibility issues using Axe devtools. Unresolved issues are described above.
- [x] Updated the documentation if necessary.

Check the [contributing guidelines](./docs/CONTRIBUTING.md) for more details.

## Screenshots (if appropriate)
